### PR TITLE
[bookworm] Disable OpenMP

### DIFF
--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -10,7 +10,7 @@ ARG LIBJXL_VERSION=0.11.1
 
 RUN apt-get -y update && \
     apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends git make pkg-config autoconf curl cmake clang libomp-dev ca-certificates automake \
+    apt-get install -y --no-install-recommends git make pkg-config autoconf curl cmake clang ca-certificates automake \
     # libaom
     yasm \
     # libheif
@@ -59,7 +59,7 @@ RUN apt-get -y update && \
     # Building ImageMagick
     git clone -b ${IM_VERSION} --depth 1 https://github.com/ImageMagick/ImageMagick.git && \
     cd ImageMagick && \
-    LIBS="-lsharpyuv" ./configure --without-magick-plus-plus --disable-docs --disable-static --with-tiff --with-jxl --with-tcmalloc && \
+    LIBS="-lsharpyuv" ./configure --without-magick-plus-plus --disable-docs --disable-static --with-tiff --with-jxl --with-tcmalloc --without-openmp && \
     make && make install && \
     ldconfig /usr/local/lib && \
     apt-get remove --autoremove --purge -y make cmake clang clang-14 curl yasm git autoconf automake pkg-config libpng-dev libjpeg62-turbo-dev libde265-dev libx265-dev libxml2-dev libtiff-dev libfontconfig1-dev libfreetype6-dev liblcms2-dev libsdl1.2-dev libgif-dev libbrotli-dev && \


### PR DESCRIPTION
Disable building with OpenMP - just in the Debian bookworm image (for now)